### PR TITLE
Use bash if installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.4
+  - 1.6
   - tip
 
 install:

--- a/Readme.md
+++ b/Readme.md
@@ -108,8 +108,7 @@ hello:
     echo world
 ```
 
- Commands are executed via `sh -c`, thus you may use shell features and
- positional variables, for example:
+ Commands are executed via `bash -c` (or `sh -c` if bash is not installed), thus you may use shell features and positional variables, for example:
 
 ```yml
 hello:

--- a/task/task.go
+++ b/task/task.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 )
 
+var shellName string
+
 // Example usage.
 type Example struct {
 	Description string
@@ -25,6 +27,14 @@ type Task struct {
 	Exec       string
 	Usage      string
 	Examples   []*Example
+}
+
+// Use bash if installed, else use shell
+path, err := exec.LookPath("bash")
+if err == nil {
+  shellName = "bash"
+} else {
+  shellName = "sh"
 }
 
 // Run the task with `args`.
@@ -48,7 +58,7 @@ func (t *Task) Run(args []string) error {
 func (t *Task) RunScript(args []string) error {
 	path := filepath.Join(t.LookupPath, t.Script)
 	args = append([]string{path}, args...)
-	cmd := exec.Command("sh", args...)
+	cmd := exec.Command(shellName, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -58,7 +68,7 @@ func (t *Task) RunScript(args []string) error {
 // RunCommand runs the `command` via the shell.
 func (t *Task) RunCommand(args []string) error {
 	args = append([]string{"-c", t.Command, "sh"}, args...)
-	cmd := exec.Command("sh", args...)
+	cmd := exec.Command(shellName, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
With this patch, commands are processed by `bash` rather than `sh`. You can use bash syntax in `command` sections.
If bash is not available on your machine, `sh` is used instead.
