### PR TITLE
Add -e option when exec sh via ''command''

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -57,7 +57,7 @@ func (t *Task) RunScript(args []string) error {
 
 // RunCommand runs the `command` via the shell.
 func (t *Task) RunCommand(args []string) error {
-	args = append([]string{"-c", t.Command, "sh"}, args...)
+	args = append([]string{"-ce", t.Command, "sh"}, args...)
 	cmd := exec.Command("sh", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
I write `set -e` at the first line every time in a `command` task. I think shell commands should stop when failing on the way.

Like a below.

```yaml
foo:
  command: |
    set -e
    echo "foo"
    type NoExistsCommand
    echo "bar"
```

In this case, `echo "bar"` doesn't execute.

I want to set to the defaults. How about you think that?

If you want to ignore this default setting then write a `set +e` at the first line in `command` task like a below.

```yaml
foo:
  command: |
    set +e
    echo "foo"
    type NoExistsCommand
    echo "bar"
```

In this case, get an error `type NoExistsCommand` and is executed `echo "bar"`.

Please close this PR If you not need.