### PR TITLE
ci: bump to latest go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.4
+  - 1.12
   - tip
 
 install:
-  - go get golang.org/x/tools/cmd/cover
   - go get -t ./...


### PR DESCRIPTION
seems sys/unix pkg can no longer run on go1.4