### PR TITLE
add robo vars to aide with chaining.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -328,6 +328,27 @@ stage:
   exec: ssh stage-tools -t robo --config stage.yml
 ```
 
+  You can also use robo's builtin variables `robo.path`, for example
+  if you put all robofiles in together:
+
+```bash
+├── dev.yml
+├── prod.yml
+├── root.yml
+└── stage.yml
+```
+
+  And you would like to call `dev`, `prod` and `stage` from `root`:
+
+```yml
+dev:
+  summary: Development commands
+  exec: robo --config {{ .robo.path }}/dev.yml
+
+stage:
+  ...
+```
+
 ## Why?
 
  We generally use Makefiles for project specific tasks, however

--- a/_examples/chain/dev.yml
+++ b/_examples/chain/dev.yml
@@ -1,0 +1,4 @@
+
+env:
+  summary: output env name
+  command: echo dev

--- a/_examples/chain/prod.yml
+++ b/_examples/chain/prod.yml
@@ -1,0 +1,4 @@
+
+env:
+  summary: output env name
+  command: echo prod

--- a/_examples/chain/root.yml
+++ b/_examples/chain/root.yml
@@ -1,0 +1,12 @@
+
+dev:
+  summary: development commands
+  exec: robo --config {{ .robo.path }}/dev.yml
+
+stage:
+  summary: development commands
+  exec: robo --config {{ .robo.path }}/stage.yml
+
+prod:
+  summary: development commands
+  exec: robo --config {{ .robo.path }}/prod.yml

--- a/_examples/chain/stage.yml
+++ b/_examples/chain/stage.yml
@@ -1,0 +1,4 @@
+
+env:
+  summary: output env name
+  command: echo stage

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -30,7 +30,10 @@ var list = `
 
 // Variables template.
 var variables = `
-{{range $k, $v := .Variables}}  {{cyan $k}} – {{$v}}
+{{- range $parent, $v := .Variables}}
+{{- range $k, $v := $v }}
+    {{cyan "%s.%s" $parent $k }}: {{$v}}
+{{- end}}
 {{end}}
 `
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,6 +41,8 @@ func TestNewString(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 4, len(c.Tasks))
 
+	assert.Equal(t, nil, c.Eval())
+
 	assert.Equal(t, `ssh bastion-stage -t robo`, c.Tasks["stage"].Command)
 	assert.Equal(t, `ssh bastion-prod -t robo`, c.Tasks["prod"].Command)
 


### PR DESCRIPTION
Even thought this is already easy to do using a global `$ROBO_PATH` or similar, it adds a step to installation guide in an org.

This removes the need for a global env var and keeps dependencies close together.