### PR TITLE
override env

### DIFF
--- a/_examples/chain/dev.yml
+++ b/_examples/chain/dev.yml
@@ -1,4 +1,4 @@
 
 env:
   summary: output env name
-  command: echo dev
+  command: echo $E

--- a/_examples/chain/prod.yml
+++ b/_examples/chain/prod.yml
@@ -1,4 +1,4 @@
 
 env:
   summary: output env name
-  command: echo prod
+  command: echo $E

--- a/_examples/chain/root.yml
+++ b/_examples/chain/root.yml
@@ -2,11 +2,14 @@
 dev:
   summary: development commands
   exec: robo --config {{ .robo.path }}/dev.yml
+  env: ["E=dev"]
 
 stage:
   summary: development commands
   exec: robo --config {{ .robo.path }}/stage.yml
+  env: ["E=stage"]
 
 prod:
   summary: development commands
   exec: robo --config {{ .robo.path }}/prod.yml
+  env: ["E=prod"]

--- a/_examples/chain/stage.yml
+++ b/_examples/chain/stage.yml
@@ -1,4 +1,4 @@
 
 env:
   summary: output env name
-  command: echo stage
+  command: echo $E

--- a/task/task.go
+++ b/task/task.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/mattn/go-shellwords"
@@ -93,7 +94,33 @@ func (t *Task) RunExec(args []string) error {
 		return err
 	}
 
-	env := append(os.Environ(), t.Env...)
+	env := merge(os.Environ(), t.Env)
 	args = append(fields, args...)
 	return syscall.Exec(path, args, env)
+}
+
+// Merge merges the given two lists of env vars.
+func merge(a, b []string) []string {
+	var items = make(map[string]string)
+	var ret []string
+
+	for _, item := range a {
+		if i := strings.Index(item, "="); i != -1 {
+			key := item[:i]
+			items[key] = item[i+1:]
+		}
+	}
+
+	for _, item := range b {
+		if i := strings.Index(item, "="); i != -1 {
+			key := item[:i]
+			items[key] = item[i+1:]
+		}
+	}
+
+	for k, v := range items {
+		ret = append(ret, k+"="+v)
+	}
+
+	return ret
 }


### PR DESCRIPTION
Seems like `syscall.Exec` doesn't automatically override env vars, unlike `exec.Command`.