### PR TITLE
robo(1): add --quiet

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -29,6 +29,9 @@ var list = `
 {{end}}
 `
 
+// Quiet list.
+var quiet = "{{range .Tasks}}{{ .Name }}\n{{end}}"
+
 // Variables template.
 var variables = `
 {{- range $k, $v := . }}
@@ -73,6 +76,12 @@ func List(c *config.Config) {
 		tmpl = t(c.Templates.List)
 	}
 
+	tmpl.Execute(os.Stdout, c)
+}
+
+// ListNames lists task names.
+func ListNames(c *config.Config) {
+	tmpl := t(quiet)
 	tmpl.Execute(os.Stdout, c)
 }
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ var version = "0.6.0"
 
 const usage = `
   Usage:
-    robo [--config file]
+    robo [-q] [--config file]
     robo <task> [<arg>...] [--config file]
     robo help [<task>] [--config file]
     robo variables [--config file]
@@ -23,6 +23,7 @@ const usage = `
     -c, --config file   config file to load [default: robo.yml]
     -h, --help          output help information
     -v, --version       output version
+    -q, --quiet         output task names only
 
   Examples:
 
@@ -62,6 +63,11 @@ func main() {
 	default:
 		if name, ok := args["<task>"].(string); ok {
 			cli.Run(c, name, args["<arg>"].([]string))
+			return
+		}
+
+		if args["--quiet"].(bool) {
+			cli.ListNames(c)
 		} else {
 			cli.List(c)
 		}


### PR DESCRIPTION
The option renders the task names only, allows users to implement scripting
easily with robo.

Closes #46.