### PR TITLE
Introduce before and after steps for a task.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -300,6 +300,30 @@ $ robo aws-stage ...
 
 Note that you cannot use shell featurs in the environment key.
 
+### Setup / Cleanup
+Some tasks or even your entire robo configuration may require steps upfront for setup or afterwards for a cleanup. The keywords `before` and `after` can be embedded into a task or into the overall robo configuration. It has the same executable syntax as a task: `script`, `exec` and `command`.
+Defining it on a task level causes the steps to be executed before (respectively after) the task. Global before or after steps are invoked for _every_ task in the configuration.
+All steps get interpolated the same way tasks and variables are interpolated.
+
+```yaml
+before:
+  - command: echo "global before {{ .foo }}"
+after:
+  - script: /global/after-script.sh
+
+foo:
+  before:
+    - command: echo "local before {{ .foo }}"
+    - exec: git pull -r
+  after:
+    - command: echo "local after"
+    - exec: git reset --hard HEAD
+  exec: git status
+
+variables:
+  foo: bar
+```
+
 ### Templates
 
  Task `list` and `help` output may be re-configured, for example if you

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -111,9 +111,13 @@ func Run(c *config.Config, name string, args []string) {
 
 	task.LookupPath = filepath.Dir(c.File)
 
-	err := task.Run(args)
-	if err != nil {
-		Fatalf("error: %s", err)
+	errs := task.Run(args)
+	if len(errs) > 0 {
+		var msg string
+		for _, err := range errs {
+			msg += fmt.Sprintf("    - %+v\n", err)
+		}
+		Fatalf("error(s): \n%s", msg)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,8 @@ import (
 // Config represents the main YAML configuration
 // loaded for Robo tasks.
 type Config struct {
+	Before    []*task.Runnable
+	After     []*task.Runnable
 	File      string
 	Tasks     map[string]*task.Task `yaml:",inline"`
 	Variables map[string]interface{}
@@ -37,6 +39,16 @@ func (c *Config) Eval() error {
 	err = interpolation.Tasks(c.Tasks, c.Variables)
 	if err != nil {
 		return fmt.Errorf("failed interpolating tasks. Error: %v", err)
+	}
+
+	err = interpolation.Optionals("before", c.Before, c.Variables)
+	if err != nil {
+		return fmt.Errorf("failed interpolating before optionals. Error: %v", err)
+	}
+
+	err = interpolation.Optionals("after", c.After, c.Variables)
+	if err != nil {
+		return fmt.Errorf("failed interpolating after optionals. Error: %v", err)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"fmt"
-	"github.com/tj/robo/interpolation"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os/user"
 	"path"
+
+	"github.com/tj/robo/interpolation"
+	"gopkg.in/yaml.v2"
 
 	"github.com/tj/robo/task"
 )
@@ -14,10 +15,10 @@ import (
 // Config represents the main YAML configuration
 // loaded for Robo tasks.
 type Config struct {
-	File         string
-	Tasks        map[string]*task.Task `yaml:",inline"`
-	Variables    map[string]interface{}
-	Templates    struct {
+	File      string
+	Tasks     map[string]*task.Task `yaml:",inline"`
+	Variables map[string]interface{}
+	Templates struct {
 		List      string
 		Help      string
 		Variables string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,7 +12,11 @@ import (
 var s = `
 foo:
   summary: Command foo.
+  before:
+  - command: echo "before"
   command: echo "foo"
+  after:
+  - command: echo "after"
 
 bar:
   summary: Command bar.
@@ -53,6 +57,8 @@ func TestNewString(t *testing.T) {
 	assert.Equal(t, `foo`, c.Tasks["foo"].Name)
 	assert.Equal(t, `Command foo.`, c.Tasks["foo"].Summary)
 	assert.Equal(t, `echo "foo"`, c.Tasks["foo"].Command)
+	assert.Equal(t, `echo "before"`, c.Tasks["foo"].Before[0].Command)
+	assert.Equal(t, `echo "after"`, c.Tasks["foo"].After[0].Command)
 
 	assert.Equal(t, `Command bar.`, c.Tasks["bar"].Summary)
 	assert.Equal(t, `echo "bar"`, c.Tasks["bar"].Command)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,12 @@ import (
 )
 
 var s = `
+before:
+- command: echo "global before"
+
+after:
+- command: echo "global after"
+
 foo:
   summary: Command foo.
   before:
@@ -54,6 +60,8 @@ func TestNewString(t *testing.T) {
 	assert.Equal(t, `ssh bastion-stage -t robo`, c.Tasks["stage"].Command)
 	assert.Equal(t, `ssh bastion-prod -t robo`, c.Tasks["prod"].Command)
 
+	assert.Equal(t, `echo "global before"`, c.Before[0].Command)
+	assert.Equal(t, `echo "global after"`, c.After[0].Command)
 	assert.Equal(t, `foo`, c.Tasks["foo"].Name)
 	assert.Equal(t, `Command foo.`, c.Tasks["foo"].Summary)
 	assert.Equal(t, `echo "foo"`, c.Tasks["foo"].Command)

--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -17,7 +17,7 @@ import (
 var commandPattern = regexp.MustCompile("\\$\\((.+)\\)")
 
 // Vars interpolates a given map of interfaces (strings or submaps) with itself
-// returning it mit populated template values.
+// returning it with populated template values.
 func Vars(vars *map[string]interface{}) error {
 	b, err := yaml.Marshal(*vars)
 	if err != nil {
@@ -112,6 +112,7 @@ func Tasks(tasks map[string]*task.Task, data map[string]interface{}) error {
 	return nil
 }
 
+// Optionals interpolates a list of runnables (i.e. optional steps for a task or the overall robo configuration).
 func Optionals(id string, rs []*task.Runnable, data map[string]interface{}) error {
 	for i, step := range rs {
 		err := interpolate(

--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -72,11 +72,12 @@ func captureCommandOutput(args string) (string, error) {
 	cmd.Stdout = &b
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	return strings.TrimSuffix(string(b.Bytes()), "\n"), err
+	return strings.TrimSuffix(b.String(), "\n"), err
 }
 
 // Tasks interpolates a given task with a set of data replacing placeholders
-// in the command, summary, script, exec and envs property.
+// in the command, summary, script, exec and envs properties. If applicable the optionals 'before' and 'after' are also
+// interpolated.
 func Tasks(tasks map[string]*task.Task, data map[string]interface{}) error {
 	for _, task := range tasks {
 		// interpolate the tasks main fields
@@ -101,17 +102,17 @@ func Tasks(tasks map[string]*task.Task, data map[string]interface{}) error {
 		}
 
 		// interpolate a task's before and after steps
-		if err := interpolateOptionals("before", task.Before, data); err != nil {
+		if err := Optionals("before", task.Before, data); err != nil {
 			return err
 		}
-		if err := interpolateOptionals("after", task.After, data); err != nil {
+		if err := Optionals("after", task.After, data); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func interpolateOptionals(id string, rs []*task.Runnable, data map[string]interface{}) error {
+func Optionals(id string, rs []*task.Runnable, data map[string]interface{}) error {
 	for i, step := range rs {
 		err := interpolate(
 			id,

--- a/task/task.go
+++ b/task/task.go
@@ -59,12 +59,20 @@ func (t *Task) runTaskOptionals(id string, rs []*Runnable, args []string) error 
 	return RunOptionals(id, t.Name, rs, args, t.LookupPath, t.Env)
 }
 
+// Runnable describes an 'executable' element defined in the overall robo configuration.
+// A valid Runnable is one of: command, script or exec.
+//
+// - command is a shell script provided as an optional multilined string.
+// - script holds the path to a script passing the given arguments straight
+// - exec describes a binary which will be looked up for execution
 type Runnable struct {
 	Command string
 	Script  string
 	Exec    string
 }
 
+// Run invokes the Runnable according to its definition.
+// An invalid (empty) Runnable will result in an error.
 func (r *Runnable) Run(lookupPath string, args []string, env []string) error {
 	if r.Exec != "" {
 		return r.RunExec(args, env)
@@ -164,6 +172,7 @@ func merge(a, b []string) []string {
 	return ret
 }
 
+// RunOptionals executes a list of runnables and immediately returns an error if one of them an error not executing the remaining ones.
 func RunOptionals(id string, parent string, rs []*Runnable, args []string, lookupPath string, envs []string) error {
 	for i, r := range rs {
 		if err := r.Run(lookupPath, args, envs); err != nil {


### PR DESCRIPTION
Hey guys, I fiddled around with some `before` and `after` functionality I could use within robo. Hopefully this finds a way into master. Let me know what you think, will update the docs after we're all happy with it :-)

A task is now able to have several steps which are executed before and after its own execution. The config syntax for this is the same as for the task itself: 'command', 'script' and 'exec' are supported. A task and all of the preceeding steps will still be executed even when the before steps are failing.

Running a task now returns a list of errors which are logged according to their occurrence for easier troubleshooting.