### PR TITLE
Ignore SIGINT while running child process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@
 test:
 	@go test -cover ./...
 
+.PHONY: dist
 dist:
 	@gox \
-		--osarch "!darwin/386" \
+		--osarch "darwin/amd64 darwin/arm64 linux/amd64 linux/arm" \
 		--output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
+	rm dist/*.gz
+	ls dist/* | while read i; do gzip $$i; done
 
 clean:
 	rm -fr dist

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tj/robo/config"
 )
 
-var version = "0.7.0"
+var version = "0.7.0-cgamesplay"
 
 const usage = `
   Usage:


### PR DESCRIPTION
This resolves #55. My notes on the implementation:

1. I had to do it in the Task section because the signal mask is inherited by the child processes, so ignoring SIGINT there actually causes the children to ignore it too. I don't see anything in the [exec package](https://pkg.go.dev/os/exec) that would allow not inheriting the signal mask, so we start the process, then mask the signal while we wait for the process to finish. It may be possible for the task to start and ignore SIGINT, and then for an external process to SIGINT the process group, both before our call to signal.Ignore, which would mean that the bug still exists. This feels extremely unlikely.
2. I only handled SIGINT. I don't think any other signals are typically delivered to an entire process group, so I think this is OK.